### PR TITLE
Add scoped key handling utility

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,6 +3,10 @@
 @tailwind components;
 @tailwind utilities;
 
+.remove-focus-outline:focus {
+    @apply outline-0;
+}
+
 .scroll-shadows-y {
     scrollbar-width: none;
     -ms-overflow-style: none;

--- a/src/lib/components/canvas.svelte
+++ b/src/lib/components/canvas.svelte
@@ -25,8 +25,9 @@
 		type EditorMode,
 		type WireData
 	} from '$lib/models/editor_mode';
-import Notifier from '$lib/util/notifier';
-import { getNotificationsContext } from 'svelte-notifications';
+    import Notifier from '$lib/util/notifier';
+    import { getNotificationsContext } from 'svelte-notifications';
+    import { on_keydown } from '$lib/util/key_handling';
 
 	let canvas: Canvas;
 	let canvasElement;
@@ -648,15 +649,26 @@ import { getNotificationsContext } from 'svelte-notifications';
 	onMount(() => {
 		console.log('Mounted canvas');
 		prepareCanvas();
+
+        // Ugly hack because fabric is braindead
+        const fabricCanvas = document.getElementsByClassName('canvas-container')[0] as HTMLElement;
+        const scopedKeydown = on_keydown(fabricCanvas, handleKeydown);
+
+        return () => {
+            scopedKeydown.destroy();
+        };
 	});
 </script>
 
-<svelte:window
-	on:resize={resizeCanvas}
-	on:keydown|preventDefault|trusted|stopPropagation={handleKeydown}
+<canvas bind:this={canvasElement}/>
+
+<svelte:window 
+    on:resize={resizeCanvas}
 />
 
-<canvas bind:this={canvasElement} />
-
 <style>
+    main {
+        @apply contents;
+    }
 </style>
+

--- a/src/lib/util/key_handling.ts
+++ b/src/lib/util/key_handling.ts
@@ -1,0 +1,21 @@
+export type CallbackType = (event: KeyboardEvent) => void;
+
+/// Sets a scoped keydown event listener on the specified node.
+export function on_keydown(node: HTMLElement, callback: CallbackType) {
+    // Makes the element focusable so it's checkable 
+    // via document.activeElement
+    node.tabIndex = -1;
+
+    // Removes focus outline from element
+    node.classList.add('remove-focus-outline');
+
+    // Add event listener to the node
+    node.addEventListener('keydown', callback);
+
+    return {
+        destroy: () => {
+            node.removeEventListener('keydown', callback);
+        }
+    };
+}
+

--- a/src/routes/simulator.svelte
+++ b/src/routes/simulator.svelte
@@ -688,7 +688,7 @@
 		{/if}
 	</aside>
 </div>
-<svelte:window on:keydown|trusted={handleKeyPress} />
+<svelte:window on:keydown|trusted|stopPropagation={handleKeyPress} />
 
 <style>
 	/*


### PR DESCRIPTION
With this utility, the keydown events are scoped to the component on which the `on_keydown` utility is used. Helps prevent global `<svelte:window on:keydown/>` pollution.